### PR TITLE
refactor(add-types): twitch provider

### DIFF
--- a/playground/server/routes/auth/twitch.get.ts
+++ b/playground/server/routes/auth/twitch.get.ts
@@ -5,7 +5,7 @@ export default oauthTwitchEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        twitch: user.login,
+        twitch: user.nickname,
       },
       loggedInAt: Date.now(),
     })

--- a/playground/server/routes/auth/twitch.get.ts
+++ b/playground/server/routes/auth/twitch.get.ts
@@ -5,7 +5,7 @@ export default oauthTwitchEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        twitch: user.nickname,
+        twitch: user.login,
       },
       loggedInAt: Date.now(),
     })

--- a/src/runtime/server/lib/oauth/steam.ts
+++ b/src/runtime/server/lib/oauth/steam.ts
@@ -44,7 +44,7 @@ export interface OAuthSteamConfig {
   redirectURL?: string
 }
 
-export function oauthSteamEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSteamConfig>): EventHandler {
+export function oauthSteamEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSteamConfig, SteamUser>): EventHandler {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.steam, {
       authorizationURL: 'https://steamcommunity.com/openid/login',

--- a/src/runtime/server/lib/oauth/twitch.ts
+++ b/src/runtime/server/lib/oauth/twitch.ts
@@ -1,9 +1,22 @@
-import type { H3Event } from 'h3'
+import type { H3Event, EventHandler } from 'h3'
 import { eventHandler, createError, getQuery, getRequestURL, sendRedirect } from 'h3'
 import { withQuery, parsePath } from 'ufo'
 import { defu } from 'defu'
 import { useRuntimeConfig } from '#imports'
-import type { OAuthConfig } from '#auth-utils'
+import type { OAuthAccessTokenError, OAuthAccessTokenSuccess, OAuthConfig, OAuthToken, OAuthUser } from '#auth-utils'
+
+/**
+ * Twitch User
+ *
+ * @see https://dev.twitch.tv/docs/api/reference/#get-users
+ */
+type TwitchUser = {
+  id: string
+  login: string
+  display_name: string
+  profile_image_url: string
+  email?: string
+}
 
 export interface OAuthTwitchConfig {
   /**
@@ -57,7 +70,7 @@ export interface OAuthTwitchConfig {
   redirectURL?: string
 }
 
-export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTwitchConfig>) {
+export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTwitchConfig, TwitchUser>): EventHandler {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.twitch, {
       authorizationURL: 'https://id.twitch.tv/oauth2/authorize',
@@ -94,9 +107,7 @@ export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthCon
       )
     }
 
-    // TODO: improve typing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tokens: any = await $fetch(
+    const tokens: any = await $fetch<unknown>(
       config.tokenURL as string,
       {
         method: 'POST',
@@ -114,20 +125,19 @@ export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthCon
     ).catch((error) => {
       return { error }
     })
-    if (tokens.error) {
+    if ((tokens as OAuthAccessTokenError).error) {
       const error = createError({
         statusCode: 401,
-        message: `Twitch login failed: ${tokens.error?.data?.error_description || 'Unknown error'}`,
-        data: tokens,
+        message: `Twitch login failed: ${(tokens as OAuthAccessTokenError).error || 'Unknown error'}`,
+        data: tokens as OAuthAccessTokenError,
       })
       if (!onError) throw error
       return onError(event, error)
     }
 
-    const accessToken = tokens.access_token
-    // TODO: improve typing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const users: any = await $fetch('https://api.twitch.tv/helix/users', {
+    const accessToken = (tokens as OAuthAccessTokenSuccess).access_token
+
+    const users = await $fetch<{ data: TwitchUser[] }>('https://api.twitch.tv/helix/users', {
       headers: {
         'Client-ID': config.clientId,
         'Authorization': `Bearer ${accessToken}`,
@@ -147,8 +157,36 @@ export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthCon
     }
 
     return onSuccess(event, {
-      tokens,
-      user,
+      user: normalizeTwitchUser(user),
+      tokens: normalizeTwitchTokens(tokens),
     })
   })
+}
+
+function normalizeTwitchUser(user: TwitchUser): OAuthUser<TwitchUser> {
+  return {
+    id: user.id,
+    nickname: user.login,
+    name: user.display_name,
+    email: user.email,
+    avatar: user.profile_image_url,
+    raw: user,
+  }
+}
+
+function normalizeTwitchTokens(tokens: TwitchAccessTokenSucces): OAuthToken {
+  return {
+    token: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresIn: tokens.expires_in,
+    approvedScopes: tokens.scope || [],
+  }
+}
+ 
+/**
+  * Authorization Tokens
+  * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#use-the-authorization-code-to-get-a-token
+  */
+interface TwitchAccessTokenSucces extends Omit<OAuthAccessTokenSuccess, 'scope'> {
+  scope?: string[]
 }


### PR DESCRIPTION
I refactored and tested the twitch provider and fixed a missing type in steam provider event handler

Twitch Documentation:
- [User Info](https://dev.twitch.tv/docs/api/reference/#get-users)
- [Tokens](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#use-the-authorization-code-to-get-a-token)

I extended the `OAuthAccessTokenSuccess` interface to create `TwitchAccessTokenSuccess`, omitting the `scope` property and redefining it as `string[]` because scope is obtained directly as an array of strings. 